### PR TITLE
Snip12 for Claims and Gateway Deployment messages

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -9,6 +9,7 @@ dependencies = [
  "openzeppelin_account",
  "openzeppelin_introspection",
  "openzeppelin_upgrades",
+ "openzeppelin_utils",
  "snforge_std",
 ]
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,6 +11,7 @@ openzeppelin_access = "1.0.0"
 openzeppelin_introspection = "1.0.0"
 openzeppelin_upgrades = "1.0.0"
 openzeppelin_account = "1.0.0"
+openzeppelin_utils = "1.0.0"
 
 [dev-dependencies]
 assert_macros = "2.11.2"

--- a/src/claim_issuer/claim_issuer.cairo
+++ b/src/claim_issuer/claim_issuer.cairo
@@ -99,7 +99,7 @@ pub mod ClaimIssuer {
     pub impl SNIP12MetadataImpl of SNIP12Metadata {
         /// Returns the name of the SNIP-12 metadata.
         fn name() -> felt252 {
-            'OnchainID'
+            'OnchainID.ClaimIssuer'
         }
 
         /// Returns the version of the SNIP-12 metadata.

--- a/src/claim_issuer/claim_issuer.cairo
+++ b/src/claim_issuer/claim_issuer.cairo
@@ -1,5 +1,6 @@
 #[starknet::contract]
 pub mod ClaimIssuer {
+    use openzeppelin_utils::cryptography::snip12::SNIP12Metadata;
     use starknet::ContractAddress;
     use starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
@@ -10,6 +11,9 @@ pub mod ClaimIssuer {
     use crate::identity::interface::iidentity::IIdentity;
     use crate::version::version;
 
+    #[abi(embed_v0)]
+    impl VersionImpl = version::VersionImpl<ContractState>;
+
     component!(path: IdentityComponent, storage: identity, event: IdentityEvent);
 
     #[abi(embed_v0)]
@@ -17,9 +21,9 @@ pub mod ClaimIssuer {
     #[abi(embed_v0)]
     impl ERC735Impl = IdentityComponent::ERC735Impl<ContractState>;
     impl IdentityInternalImpl = IdentityComponent::InternalImpl<ContractState>;
-
     #[abi(embed_v0)]
-    impl VersionImpl = version::VersionImpl<ContractState>;
+    impl SNIP12MetadataExternalImpl =
+        IdentityComponent::SNIP12MetadataExternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
@@ -89,6 +93,18 @@ pub mod ClaimIssuer {
                 return false;
             }
             self.identity.is_claim_valid(identity, claim_topic, signature, data)
+        }
+    }
+
+    pub impl SNIP12MetadataImpl of SNIP12Metadata {
+        /// Returns the name of the SNIP-12 metadata.
+        fn name() -> felt252 {
+            'OnchainID'
+        }
+
+        /// Returns the version of the SNIP-12 metadata.
+        fn version() -> felt252 {
+            version::VERSION
         }
     }
 

--- a/src/gateway/interface.cairo
+++ b/src/gateway/interface.cairo
@@ -1,3 +1,6 @@
+use core::hash::{HashStateExTrait, HashStateTrait};
+use core::poseidon::PoseidonTrait;
+use openzeppelin_utils::cryptography::snip12::{SNIP12HashSpanImpl, StructHash};
 use starknet::ContractAddress;
 
 #[derive(Copy, Debug, Drop, Serde, Hash)]
@@ -5,6 +8,61 @@ pub struct Signature {
     pub r: felt252,
     pub s: felt252,
     pub y_parity: bool,
+}
+
+#[derive(Copy, Drop, Serde)]
+pub struct Deployment {
+    pub identity_owner: ContractAddress,
+    pub salt: felt252,
+    pub expiration: u64,
+}
+
+pub const DEPLOYMENT_TYPEHASH: felt252 = selector!(
+    "\"Deployment\"(
+        \"identity_owner\":\"ContractAddress\",
+        \"salt\":\"felt\",
+        \"expiration\":\"u128\",
+    )",
+);
+
+pub impl DeploymentStructHash of StructHash<Deployment> {
+    fn hash_struct(self: @Deployment) -> felt252 {
+        PoseidonTrait::new()
+            .update_with(DEPLOYMENT_TYPEHASH)
+            .update_with(*self.identity_owner)
+            .update_with(*self.salt)
+            .update_with(*self.expiration)
+            .finalize()
+    }
+}
+
+#[derive(Copy, Drop, Serde)]
+pub struct DeploymentWithManagementKeys {
+    pub identity_owner: ContractAddress,
+    pub salt: felt252,
+    pub management_keys: Span<felt252>,
+    pub expiration: u64,
+}
+
+pub const DEPLOYMENT_WITH_MANAGEMENT_KEYS_TYPEHASH: felt252 = selector!(
+    "\"DeploymentWithManagementKeys\"(
+        \"identity_owner\":\"ContractAddress\",
+        \"salt\":\"felt\",
+        \"management_keys\":\"felt*\",
+        \"expiration\":\"u128\",
+    )",
+);
+
+pub impl DeploymentWithManagementKeysStructHash of StructHash<DeploymentWithManagementKeys> {
+    fn hash_struct(self: @DeploymentWithManagementKeys) -> felt252 {
+        PoseidonTrait::new()
+            .update_with(DEPLOYMENT_WITH_MANAGEMENT_KEYS_TYPEHASH)
+            .update_with(*self.identity_owner)
+            .update_with(*self.salt)
+            .update_with(*self.management_keys)
+            .update_with(*self.expiration)
+            .finalize()
+    }
 }
 
 #[starknet::interface]

--- a/src/identity/component.cairo
+++ b/src/identity/component.cairo
@@ -2,6 +2,7 @@
 pub mod IdentityComponent {
     use core::num::traits::Zero;
     use core::poseidon::poseidon_hash_span;
+    use openzeppelin_utils::cryptography::interface::ISNIP12Metadata;
     use openzeppelin_utils::cryptography::snip12::{OffchainMessageHash, SNIP12Metadata};
     use starknet::ContractAddress;
     use starknet::storage::{
@@ -62,7 +63,7 @@ pub mod IdentityComponent {
 
     #[embeddable_as(IdentityImpl)]
     pub impl Identity<
-        TContractState, +Drop<TContractState>, +HasComponent<TContractState>,
+        TContractState, +Drop<TContractState>, +HasComponent<TContractState>, +SNIP12Metadata,
     > of IIdentity<ComponentState<TContractState>> {
         fn is_claim_valid(
             self: @ComponentState<TContractState>,
@@ -515,15 +516,13 @@ pub mod IdentityComponent {
         }
     }
 
-    pub impl SNIP12MetadataImpl of SNIP12Metadata {
-        /// Returns the name of the SNIP-12 metadata.
-        fn name() -> felt252 {
-            'OnchainID'
-        }
-
-        /// Returns the version of the SNIP-12 metadata.
-        fn version() -> felt252 {
-            'v1'
+    #[embeddable_as(SNIP12MetadataExternalImpl)]
+    pub impl SNIP12MetadataExternal<
+        TContractState, +HasComponent<TContractState>, impl Metadata: SNIP12Metadata,
+    > of ISNIP12Metadata<ComponentState<TContractState>> {
+        /// Returns the domain name and version used to generate the message hash.
+        fn snip12_metadata(self: @ComponentState<TContractState>) -> (felt252, felt252) {
+            (Metadata::name(), Metadata::version())
         }
     }
 

--- a/src/identity/identity.cairo
+++ b/src/identity/identity.cairo
@@ -91,7 +91,7 @@ pub mod Identity {
     pub impl SNIP12MetadataImpl of SNIP12Metadata {
         /// Returns the name of the SNIP-12 metadata.
         fn name() -> felt252 {
-            'OnchainID'
+            'OnchainID.Identity'
         }
 
         /// Returns the version of the SNIP-12 metadata.

--- a/src/identity/identity.cairo
+++ b/src/identity/identity.cairo
@@ -1,8 +1,9 @@
 #[starknet::contract]
-mod Identity {
+pub mod Identity {
     use core::num::traits::Zero;
     use openzeppelin_upgrades::interface::IUpgradeable;
     use openzeppelin_upgrades::upgradeable::UpgradeableComponent;
+    use openzeppelin_utils::cryptography::snip12::SNIP12Metadata;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ClassHash, ContractAddress};
     use crate::identity::component::IdentityComponent;
@@ -25,6 +26,10 @@ mod Identity {
 
     #[abi(embed_v0)]
     impl ERC735Impl = IdentityComponent::ERC735Impl<ContractState>;
+
+    #[abi(embed_v0)]
+    impl SNIP12MetadataExternalImpl =
+        IdentityComponent::SNIP12MetadataExternalImpl<ContractState>;
 
     impl IdentityInternalImpl = IdentityComponent::InternalImpl<ContractState>;
 
@@ -80,6 +85,18 @@ mod Identity {
                 Errors::CALLER_NOT_IMPLEMENTATION_AUTHORITY,
             );
             self.upgradeable.upgrade(new_class_hash);
+        }
+    }
+
+    pub impl SNIP12MetadataImpl of SNIP12Metadata {
+        /// Returns the name of the SNIP-12 metadata.
+        fn name() -> felt252 {
+            'OnchainID'
+        }
+
+        /// Returns the version of the SNIP-12 metadata.
+        fn version() -> felt252 {
+            version::VERSION
         }
     }
 }

--- a/tests/claim_issuers/claim_issuer_test.cairo
+++ b/tests/claim_issuers/claim_issuer_test.cairo
@@ -142,7 +142,7 @@ pub mod revoke_claim {
 
 pub mod is_claim_valid {
     use onchain_id_starknet::claim_issuer::interface::ClaimIssuerABIDispatcherTrait;
-    use onchain_id_starknet::identity::component::IdentityComponent::SNIP12MetadataImpl;
+    use onchain_id_starknet::identity::identity::Identity::SNIP12MetadataImpl;
     use onchain_id_starknet::storage::signature::{ClaimMessage, Signature, StarkSignature};
     use openzeppelin_utils::cryptography::snip12::OffchainMessageHash;
     use snforge_std::signature::SignerTrait;

--- a/tests/claim_issuers/claim_issuer_test.cairo
+++ b/tests/claim_issuers/claim_issuer_test.cairo
@@ -141,9 +141,10 @@ pub mod revoke_claim {
 }
 
 pub mod is_claim_valid {
-    use core::poseidon::poseidon_hash_span;
     use onchain_id_starknet::claim_issuer::interface::ClaimIssuerABIDispatcherTrait;
-    use onchain_id_starknet::storage::signature::{Signature, StarkSignature};
+    use onchain_id_starknet::identity::component::IdentityComponent::SNIP12MetadataImpl;
+    use onchain_id_starknet::storage::signature::{ClaimMessage, Signature, StarkSignature};
+    use openzeppelin_utils::cryptography::snip12::OffchainMessageHash;
     use snforge_std::signature::SignerTrait;
     use snforge_std::signature::stark_curve::{
         StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl,
@@ -158,11 +159,11 @@ pub mod is_claim_valid {
             @setup, setup.alice_identity.contract_address, 42_felt252, [0x0042].span(),
         );
 
-        let mut data_to_hash = array![test_claim.identity.into(), test_claim.topic];
-        test_claim.data.serialize(ref data_to_hash);
-        let hashed_claim = poseidon_hash_span(
-            array!['Starknet Message', poseidon_hash_span(data_to_hash.span())].span(),
-        );
+        let hashed_claim = ClaimMessage {
+            identity: test_claim.identity, topic: test_claim.topic, data: test_claim.data,
+        }
+            .get_message_hash(setup.claim_issuer.contract_address);
+
         test_claim.issuer = setup.accounts.bob_account.contract_address;
         let (r, s) = setup.accounts.bob_key.sign(hashed_claim).unwrap();
         let signature = Signature::StarkSignature(
@@ -210,18 +211,12 @@ pub mod is_claim_valid {
             @setup, setup.alice_identity.contract_address, 42_felt252, [0x0042].span(),
         );
 
-        let mut serialized_claim_to_sign: Array<felt252> = array![];
-        test_claim.identity.serialize(ref serialized_claim_to_sign);
-        test_claim.topic.serialize(ref serialized_claim_to_sign);
-        // different than message we are passing
-        let claim_data: ByteArray = "0xBadBabe0000";
-        claim_data.serialize(ref serialized_claim_to_sign);
-        let hashed_invalid_claim = poseidon_hash_span(
-            array!['Starknet Message', poseidon_hash_span(serialized_claim_to_sign.span())].span(),
-        );
-        let (r, s) = setup.accounts.claim_issuer_key.sign(hashed_invalid_claim).unwrap();
         let signature = Signature::StarkSignature(
-            StarkSignature { r, s, public_key: setup.accounts.claim_issuer_key.public_key },
+            StarkSignature {
+                r: 'random_r',
+                s: 'random_s',
+                public_key: setup.accounts.claim_issuer_key.public_key,
+            },
         );
         let mut serialized_signature = Default::default();
         signature.serialize(ref serialized_signature);

--- a/tests/common.cairo
+++ b/tests/common.cairo
@@ -3,13 +3,15 @@ use onchain_id_starknet::claim_issuer::interface::{
     ClaimIssuerABIDispatcher, ClaimIssuerABIDispatcherTrait,
 };
 use onchain_id_starknet::factory::interface::{IIdFactoryDispatcher, IIdFactoryDispatcherTrait};
+use onchain_id_starknet::identity::component::IdentityComponent::SNIP12MetadataImpl;
 use onchain_id_starknet::identity::interface::iidentity::{
     IdentityABIDispatcher, IdentityABIDispatcherTrait,
 };
 use onchain_id_starknet::proxy::interface::IIdentityImplementationAuthorityDispatcher;
-use onchain_id_starknet::storage::signature::{Signature, StarkSignature};
+use onchain_id_starknet::storage::signature::{ClaimMessage, Signature, StarkSignature};
 use onchain_id_starknet::verifiers::interface::{VerifierABIDispatcher, VerifierABIDispatcherTrait};
 use openzeppelin_account::interface::AccountABIDispatcher;
+use openzeppelin_utils::cryptography::snip12::OffchainMessageHash;
 use snforge_std::signature::stark_curve::{
     StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl,
 };
@@ -255,15 +257,10 @@ pub fn setup_identity() -> IdentitySetup {
     let claim_data = [0x00666].span();
     let claim_id = poseidon_hash_span(array![issuer.into(), claim_topic].span());
 
-    let mut serialized_claim_to_sign: Array<felt252> = array![];
-    alice_identity.contract_address.serialize(ref serialized_claim_to_sign);
-    claim_topic.serialize(ref serialized_claim_to_sign);
-    claim_data.serialize(ref serialized_claim_to_sign);
-
-    let hashed_claim = poseidon_hash_span(
-        array!['Starknet Message', poseidon_hash_span(serialized_claim_to_sign.span())].span(),
-    );
-
+    let mut claim_message = ClaimMessage {
+        identity: alice_identity.contract_address, topic: claim_topic, data: claim_data,
+    };
+    let hashed_claim = claim_message.get_message_hash(issuer);
     let (r, s) = factory_setup.accounts.claim_issuer_key.sign(hashed_claim).unwrap();
 
     let alice_claim_666_signature = Signature::StarkSignature(
@@ -364,14 +361,8 @@ pub fn get_test_claim(
     let issuer = *setup.claim_issuer.contract_address;
     let claim_id = poseidon_hash_span(array![issuer.into(), claim_topic].span());
 
-    let mut serialized_claim_to_sign: Array<felt252> = array![];
-    identity.serialize(ref serialized_claim_to_sign);
-    claim_topic.serialize(ref serialized_claim_to_sign);
-    claim_data.serialize(ref serialized_claim_to_sign);
-
-    let hashed_claim = poseidon_hash_span(
-        array!['Starknet Message', poseidon_hash_span(serialized_claim_to_sign.span())].span(),
-    );
+    let mut claim_message = ClaimMessage { identity, topic: claim_topic, data: claim_data };
+    let hashed_claim = claim_message.get_message_hash(issuer);
 
     let (r, s) = (*setup.accounts.claim_issuer_key).sign(hashed_claim).unwrap();
     let signature = Signature::StarkSignature(

--- a/tests/common.cairo
+++ b/tests/common.cairo
@@ -3,7 +3,7 @@ use onchain_id_starknet::claim_issuer::interface::{
     ClaimIssuerABIDispatcher, ClaimIssuerABIDispatcherTrait,
 };
 use onchain_id_starknet::factory::interface::{IIdFactoryDispatcher, IIdFactoryDispatcherTrait};
-use onchain_id_starknet::identity::component::IdentityComponent::SNIP12MetadataImpl;
+use onchain_id_starknet::identity::identity::Identity::SNIP12MetadataImpl;
 use onchain_id_starknet::identity::interface::iidentity::{
     IdentityABIDispatcher, IdentityABIDispatcherTrait,
 };

--- a/tests/identities/claims_test.cairo
+++ b/tests/identities/claims_test.cairo
@@ -1,7 +1,7 @@
 pub mod add_claim {
     pub mod when_self_attested_claim {
         use core::poseidon::poseidon_hash_span;
-        use onchain_id_starknet::identity::component::IdentityComponent::SNIP12MetadataImpl;
+        use onchain_id_starknet::identity::identity::Identity::SNIP12MetadataImpl;
         use onchain_id_starknet::identity::interface::ierc735;
         use onchain_id_starknet::identity::interface::iidentity::IdentityABIDispatcherTrait;
         use onchain_id_starknet::storage::signature::{ClaimMessage, Signature, StarkSignature};
@@ -504,7 +504,7 @@ pub mod add_claim {
 }
 
 pub mod update_claim {
-    use onchain_id_starknet::identity::component::IdentityComponent::SNIP12MetadataImpl;
+    use onchain_id_starknet::identity::identity::Identity::SNIP12MetadataImpl;
     use onchain_id_starknet::identity::interface::ierc735;
     use onchain_id_starknet::identity::interface::iidentity::IdentityABIDispatcherTrait;
     use onchain_id_starknet::storage::signature::{ClaimMessage, Signature, StarkSignature};

--- a/tests/verifiers/verifier_test.cairo
+++ b/tests/verifiers/verifier_test.cairo
@@ -106,7 +106,7 @@ pub mod verify {
                 test_claim.scheme,
                 test_claim.issuer,
                 test_claim.signature,
-                test_claim.data.clone(),
+                test_claim.data,
                 test_claim.uri.clone(),
             );
         stop_cheat_caller_address(setup.alice_identity.contract_address);


### PR DESCRIPTION
Altered the format of claims and deployment messages to be signed to comply with SNIP12. Signer address while constructing the message is assigned to claim issuer address for Identity and gateway contract for deployment messages, to represent the verifying contract. 
### Important: 
Identity `is_claim_valid` implementation only returns true for claims issued by address `is_claim_valid` called on.